### PR TITLE
internal: clarify the specific ref of ctxgroup

### DIFF
--- a/internal/ctxgroup/README.md
+++ b/internal/ctxgroup/README.md
@@ -1,5 +1,5 @@
 This has been vendored from CockroachDB to avoid large dependencies.
 It is made available under the Apache 2.0 License.
+https://github.com/cockroachdb/cockroach/blob/126ebfda589553ecb26e0c0bf5b43c4332581465/pkg/util/ctxgroup/ctxgroup.go
 
-When Go modules make it possible to avoid pulling in the entirety of a project
-for a submodule, this can be removed.
+When Go modules make it possible to avoid pulling in the entirety of a project for a submodule, this can be removed.

--- a/internal/ctxgroup/ctxgroup.go
+++ b/internal/ctxgroup/ctxgroup.go
@@ -1,12 +1,16 @@
 // Copyright 2018 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
 
 /*
 Package ctxgroup wraps golang.org/x/sync/errgroup with a context func.
@@ -168,11 +172,10 @@ func (g Group) GoCtx(f func(ctx context.Context) error) {
 }
 
 // GroupWorkers runs num worker go routines in an errgroup.
-func GroupWorkers(ctx context.Context, num int, f func(context.Context, int) error) error {
+func GroupWorkers(ctx context.Context, num int, f func(context.Context) error) error {
 	group := WithContext(ctx)
 	for i := 0; i < num; i++ {
-		workerID := i
-		group.GoCtx(func(ctx context.Context) error { return f(ctx, workerID) })
+		group.GoCtx(f)
 	}
 	return group.Wait()
 }


### PR DESCRIPTION
This is to further document that this is not a violation of the BSL.

Signed-off-by: Jimmy Zelinskie <jimmy@zelinskie.com>