### PR TITLE
Add prefix middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/authzed/grpcutil v0.0.0-20210913124023-cad23ae5a9e8
 	github.com/envoyproxy/protoc-gen-validate v0.6.1
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.6.0
 	github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70
 	github.com/stretchr/testify v1.7.0

--- a/pkg/prefix/prefix.go
+++ b/pkg/prefix/prefix.go
@@ -1,0 +1,84 @@
+package prefix
+
+import (
+	"context"
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type ctxKeyType string
+
+// ctxPrefixKey is for storing/fetching from a context
+var ctxPrefixKey ctxKeyType = "prefix"
+
+// grpcMDPrefixKey is for storing/fetching from grpc MD (must be a string)
+const grpcMDPrefixKey = "spicedb-prefix"
+
+// WithPrefixUnaryClientInterceptor annotates requests with the desired prefix
+func WithPrefixUnaryClientInterceptor(prefix string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, callOpts ...grpc.CallOption,
+	) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, grpcMDPrefixKey, prefix)
+		return invoker(ctx, method, req, reply, cc, callOpts...)
+	}
+}
+
+// WithPrefixStreamClientInterceptor annotates requests with the desired prefix
+func WithPrefixStreamClientInterceptor(prefix string) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = metadata.AppendToOutgoingContext(ctx, grpcMDPrefixKey, prefix)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+// PrefixFromContext reads the prefix from the context
+func PrefixFromContext(ctx context.Context) string {
+	if c := ctx.Value(ctxPrefixKey); c != nil {
+		return c.(string)
+	}
+	return ""
+}
+
+// MustPrefixFromContext reads the prefix from the context and panics if it has
+// not been set on the context.
+func MustPrefixFromContext(ctx context.Context) string {
+	prefix := PrefixFromContext(ctx)
+	if prefix == "" {
+		panic("prefix missing")
+	}
+	return prefix
+}
+
+// UnaryServerInterceptor returns a new unary server interceptor that extracts
+// the prefix from the request metadata and adds it to the context
+func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	prefix := metautils.ExtractIncoming(ctx).Get(grpcMDPrefixKey)
+	return handler(context.WithValue(ctx, ctxPrefixKey, prefix), req)
+}
+
+// StreamServerInterceptor returns a new stream server interceptor that extracts
+// the prefix from the request metadata and adds it to the context
+func StreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	wrapper := &recvWrapper{stream, stream.Context(), stream.Context()}
+	return handler(srv, wrapper)
+}
+
+type recvWrapper struct {
+	grpc.ServerStream
+	initialCtx context.Context
+	ctx        context.Context
+}
+
+func (s *recvWrapper) Context() context.Context {
+	return s.ctx
+}
+
+func (s *recvWrapper) RecvMsg(m interface{}) error {
+	if err := s.ServerStream.RecvMsg(m); err != nil {
+		return err
+	}
+	prefix := metautils.ExtractIncoming(s.initialCtx).Get(grpcMDPrefixKey)
+	s.ctx = context.WithValue(s.initialCtx, ctxPrefixKey, prefix)
+	return nil
+}

--- a/pkg/prefix/prefix.go
+++ b/pkg/prefix/prefix.go
@@ -2,6 +2,7 @@ package prefix
 
 import (
 	"context"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -15,8 +16,8 @@ var ctxPrefixKey ctxKeyType = "prefix"
 // grpcMDPrefixKey is for storing/fetching from grpc MD (must be a string)
 const grpcMDPrefixKey = "spicedb-prefix"
 
-// WithPrefixUnaryClientInterceptor annotates requests with the desired prefix
-func WithPrefixUnaryClientInterceptor(prefix string) grpc.UnaryClientInterceptor {
+// WithUnaryClientInterceptor annotates requests with the desired prefix
+func WithUnaryClientInterceptor(prefix string) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, callOpts ...grpc.CallOption,
 	) error {
 		ctx = metadata.AppendToOutgoingContext(ctx, grpcMDPrefixKey, prefix)
@@ -24,26 +25,26 @@ func WithPrefixUnaryClientInterceptor(prefix string) grpc.UnaryClientInterceptor
 	}
 }
 
-// WithPrefixStreamClientInterceptor annotates requests with the desired prefix
-func WithPrefixStreamClientInterceptor(prefix string) grpc.StreamClientInterceptor {
+// WithStreamClientInterceptor annotates requests with the desired prefix
+func WithStreamClientInterceptor(prefix string) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		ctx = metadata.AppendToOutgoingContext(ctx, grpcMDPrefixKey, prefix)
 		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
 
-// PrefixFromContext reads the prefix from the context
-func PrefixFromContext(ctx context.Context) string {
+// FromContext reads the prefix from the context
+func FromContext(ctx context.Context) string {
 	if c := ctx.Value(ctxPrefixKey); c != nil {
 		return c.(string)
 	}
 	return ""
 }
 
-// MustPrefixFromContext reads the prefix from the context and panics if it has
+// MustFromContext reads the prefix from the context and panics if it has
 // not been set on the context.
-func MustPrefixFromContext(ctx context.Context) string {
-	prefix := PrefixFromContext(ctx)
+func MustFromContext(ctx context.Context) string {
+	prefix := FromContext(ctx)
 	if prefix == "" {
 		panic("prefix missing")
 	}

--- a/pkg/prefix/prefix_test.go
+++ b/pkg/prefix/prefix_test.go
@@ -1,0 +1,102 @@
+package prefix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	grpc_testing "github.com/grpc-ecosystem/go-grpc-middleware/testing"
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+)
+
+const testPrefix = "test_prefix"
+
+type testServer struct{}
+
+func (t testServer) PingEmpty(ctx context.Context, empty *pb_testproto.Empty) (*pb_testproto.PingResponse, error) {
+	return &pb_testproto.PingResponse{Value: MustFromContext(ctx)}, nil
+}
+
+func (t testServer) Ping(ctx context.Context, request *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
+	return &pb_testproto.PingResponse{Value: MustFromContext(ctx)}, nil
+}
+
+func (t testServer) PingError(ctx context.Context, request *pb_testproto.PingRequest) (*pb_testproto.Empty, error) {
+	return nil, fmt.Errorf("err")
+}
+
+func (t testServer) PingList(request *pb_testproto.PingRequest, server pb_testproto.TestService_PingListServer) error {
+	return server.Send(&pb_testproto.PingResponse{Value: MustFromContext(server.Context())})
+}
+
+func (t testServer) PingStream(stream pb_testproto.TestService_PingStreamServer) error {
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(&pb_testproto.PingResponse{
+			Value: MustFromContext(stream.Context()),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestConsistencyTestSuite(t *testing.T) {
+	s := &PrefixMiddlewareTestSuite{
+		InterceptorTestSuite: &grpc_testing.InterceptorTestSuite{
+			TestService: &testServer{},
+			ServerOpts: []grpc.ServerOption{
+				grpc.StreamInterceptor(StreamServerInterceptor),
+				grpc.UnaryInterceptor(UnaryServerInterceptor),
+			},
+			ClientOpts: []grpc.DialOption{
+				grpc.WithUnaryInterceptor(WithUnaryClientInterceptor(testPrefix)),
+				grpc.WithStreamInterceptor(WithStreamClientInterceptor(testPrefix)),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+var goodPing = &pb_testproto.PingRequest{Value: "something"}
+
+type PrefixMiddlewareTestSuite struct {
+	*grpc_testing.InterceptorTestSuite
+}
+
+func (s *PrefixMiddlewareTestSuite) TestValidPasses_Unary() {
+	resp, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), testPrefix, resp.Value)
+}
+
+func (s *PrefixMiddlewareTestSuite) TestValidPasses_ServerList() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err)
+	resp, err := stream.Recv()
+	assert.NoError(s.T(), err, "no error on messages sent occurred")
+	require.Equal(s.T(), testPrefix, resp.Value)
+}
+
+func (s *PrefixMiddlewareTestSuite) TestValidPasses_ServerStream() {
+	stream, err := s.Client.PingStream(s.SimpleCtx())
+	require.NoError(s.T(), err)
+	for i := 0; i < 3; i++ {
+		require.NoError(s.T(), stream.Send(goodPing))
+		resp, err := stream.Recv()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), testPrefix, resp.Value)
+	}
+}


### PR DESCRIPTION
This adds:
 - Client middleware that can add a prefix header to grpc metadata
 - Server middleware that can extract prefix headers from grpc metadata and inject into the server's `context.Context`
 - Utilities for reading the prefix from the context.