### PR TITLE
Prepare for merge queue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ on:  # yamllint disable-line rule:truthy
       - "main"
   pull_request:
     branches: ["*"]
+  merge_group:
+    types:
+      - "checks_requested"
 jobs:
   test:
     name: "Run Integration Tests"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
-      - uses: "actions/setup-go@v3"
+      - uses: "actions/setup-go@v4"
         with:
           go-version: "~1.20"
       - uses: "authzed/action-spicedb@v1"
@@ -29,7 +29,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
-      - uses: "actions/setup-go@v3"
+      - uses: "actions/setup-go@v4"
         with:
           go-version: "~1.20"
       - name: "Install Go Tools"

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -9,6 +9,9 @@ on:  # yamllint disable-line rule:truthy
       - "opened"
       - "closed"
       - "synchronize"
+  merge_group:
+    types:
+      - "checks_requested"
 jobs:
   cla:
     name: "Check Signature"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,9 @@ on:  # yamllint disable-line rule:truthy
       - "main"
   pull_request:
     branches: ["*"]
+  merge_group:
+    types:
+      - "checks_requested"
 jobs:
   go-lint:
     name: "Lint Go"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
-      - uses: "actions/setup-go@v3"
+      - uses: "actions/setup-go@v4"
         with:
           go-version: "~1.19"
       - uses: "authzed/actions/gofumpt@main"


### PR DESCRIPTION
Enabling merge queue will reduce the rebase overhead for dependabot PRs
This PR also enables GHA setup-go v4, which comes with caching enabled by default