### PR TITLE
fix: issue with switch when err is nil

### DIFF
--- a/v1/retryable_client.go
+++ b/v1/retryable_client.go
@@ -91,6 +91,9 @@ func (rc *RetryableClient) RetryableBulkImportRelationships(ctx context.Context,
 	})
 
 	_, err = bulkImportClient.CloseAndRecv() // transaction commit happens here
+	if err == nil {
+		return nil
+	}
 
 	// Failure to commit transaction means the stream is closed, so it can't be reused any further
 	// The retry will be done using WriteRelationships instead of BulkImportRelationships
@@ -98,32 +101,24 @@ func (rc *RetryableClient) RetryableBulkImportRelationships(ctx context.Context,
 	retryable := isRetryableError(err)
 	conflict := isAlreadyExistsError(err)
 	canceled, cancelErr := isCanceledError(ctx.Err(), err)
-	unknown := !retryable && !conflict && !canceled && err != nil
+	unknown := !retryable && !conflict && !canceled
 
-	if err != nil {
-		switch {
-		case canceled:
-
-			return cancelErr
-		case unknown:
-
-			return fmt.Errorf("error finalizing write of %d relationships: %w", len(relationships), err)
-		case conflict && conflictStrategy == Skip:
-
-		case retryable || (conflict && conflictStrategy == Touch):
-			err = rc.writeBatchesWithRetry(ctx, relationships)
-			if err != nil {
-				return fmt.Errorf("failed to write relationships after retry: %w", err)
-			}
-		case conflict && conflictStrategy == Fail:
-			return fmt.Errorf("duplicate relationships found")
-
-		default:
-			return fmt.Errorf("error finalizing write of %d relationships: %w", len(relationships), err)
+	switch {
+	case canceled:
+		return cancelErr
+	case unknown:
+		return fmt.Errorf("error finalizing write of %d relationships: %w", len(relationships), err)
+	case retryable || (conflict && conflictStrategy == Touch):
+		err = rc.writeBatchesWithRetry(ctx, relationships)
+		if err != nil {
+			return fmt.Errorf("failed to write relationships after retry: %w", err)
 		}
+		return nil
+	case conflict && conflictStrategy == Fail:
+		return fmt.Errorf("duplicate relationships found")
+	default:
+		return fmt.Errorf("error finalizing write of %d relationships: %w", len(relationships), err)
 	}
-
-	return nil
 }
 
 func (rc *RetryableClient) writeBatchesWithRetry(ctx context.Context, relationships []*v1.Relationship) error {

--- a/v1/retryable_client.go
+++ b/v1/retryable_client.go
@@ -101,13 +101,10 @@ func (rc *RetryableClient) RetryableBulkImportRelationships(ctx context.Context,
 	retryable := isRetryableError(err)
 	conflict := isAlreadyExistsError(err)
 	canceled, cancelErr := isCanceledError(ctx.Err(), err)
-	unknown := !retryable && !conflict && !canceled
 
 	switch {
 	case canceled:
 		return cancelErr
-	case unknown:
-		return fmt.Errorf("error finalizing write of %d relationships: %w", len(relationships), err)
 	case retryable || (conflict && conflictStrategy == Touch):
 		err = rc.writeBatchesWithRetry(ctx, relationships)
 		if err != nil {

--- a/v1/retryable_client.go
+++ b/v1/retryable_client.go
@@ -105,6 +105,8 @@ func (rc *RetryableClient) RetryableBulkImportRelationships(ctx context.Context,
 	switch {
 	case canceled:
 		return cancelErr
+	case conflict && conflictStrategy == Skip:
+		return nil
 	case retryable || (conflict && conflictStrategy == Touch):
 		err = rc.writeBatchesWithRetry(ctx, relationships)
 		if err != nil {


### PR DESCRIPTION
Wrapping the switch statement in `if err != nil` check as it was erroneously returning an error when falling into the `default` block even when there was no error