### PR TITLE
Use centralized Go version in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,6 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
-env:
-  GO_VERSION: "~1.21.3"
 jobs:
   test:
     name: "Run Integration Tests"
@@ -18,8 +16,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/action-spicedb@v1"
       - name: "Unit tests"
         run: "go run magefile.go test:integration"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,8 +10,6 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
-env:
-  GO_VERSION: "~1.21.3"
 jobs:
   go-lint:
     name: "Lint Go"
@@ -19,8 +17,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - name: "Lint Go"
         run: "go run magefile.go lint:go"
       - name: "Go Mod Tidy"
@@ -34,8 +30,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - uses: "chainguard-dev/actions/nodiff@main"
         with:
           path: ""
@@ -46,8 +40,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - name: "Lint Go"
         run: "go run magefile.go lint:extra"
   codeql:


### PR DESCRIPTION
Removes `GO_VERSION` from our CI config because it is centrally configured in `authzed/actions/setup-go`.