### PR TITLE
RequestID utilities

### DIFF
--- a/pkg/requestmeta/requestmeta.go
+++ b/pkg/requestmeta/requestmeta.go
@@ -29,6 +29,13 @@ const (
 	// the New Enemy Problem. This is only used with the CockroachDB datastore,
 	// and only if user-provided request overlap is enabled.
 	RequestOverlapKey RequestMetadataHeaderKey = "io.spicedb.requestoverlapkey"
+
+	// RequestIDKey, if specified in a request header, will propagate the given string value
+	// through SpiceDB for the lifetime of the request. This can be used to correlate logs
+	// and traces with a specific request.
+	//
+	// TODO(alecmerdler): This is duplicated in SpiceDB source; we should be importing it from here.
+	RequestIDKey RequestMetadataHeaderKey = "x-request-id"
 )
 
 // AddRequestHeaders returns a new context with the given values as request headers.
@@ -53,4 +60,8 @@ func SetRequestHeaders(ctx context.Context, values map[RequestMetadataHeaderKey]
 // WithOverlapKey returns a new context with the overlap key set.
 func WithOverlapKey(ctx context.Context, key string) context.Context {
 	return metadata.AppendToOutgoingContext(ctx, string(RequestOverlapKey), key)
+}
+
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, string(RequestIDKey), requestID)
 }


### PR DESCRIPTION
Adds function to inject a request ID into the gRPC headers when making a request to SpiceDB. This will be used to enable the `--request-id` flag in the `zed` CLI.