### PR TITLE
Remove TODO for duplicated request ID definition

### DIFF
--- a/pkg/requestmeta/requestmeta.go
+++ b/pkg/requestmeta/requestmeta.go
@@ -33,8 +33,6 @@ const (
 	// RequestIDKey, if specified in a request header, will propagate the given string value
 	// through SpiceDB for the lifetime of the request. This can be used to correlate logs
 	// and traces with a specific request.
-	//
-	// TODO(alecmerdler): This is duplicated in SpiceDB source; we should be importing it from here.
 	RequestIDKey RequestMetadataHeaderKey = "x-request-id"
 )
 


### PR DESCRIPTION
SpiceDB is now correctly importing the request ID metadata key from this library, rather than defining it separately.

https://github.com/authzed/spicedb/pull/1829