### PR TITLE
enables dependabot update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@ updates:
       interval: "weekly"
     labels:
       - "area/dependencies"
+    groups:
+      go-mod:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
This makes it easier to handle dependabot updates because PRs don't have to be rebased due to `go.sum` conflicts.