### PR TITLE
Add a test, add to README, add test running

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: ["*"]
 jobs:
-  pytest:
+  tests:
     name: "Unit and Integration Tests"
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+---
+name: "Test"
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches: ["*"]
+jobs:
+  pytest:
+    name: "Unit and Integration Tests"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-go@v5"
+      - uses: "authzed/action-spicedb@v1"
+        with:
+          version: "latest"
+      - name: "Run tests"
+        run: "go test ./..."

--- a/README.md
+++ b/README.md
@@ -144,3 +144,23 @@ func main() {
 	}
 }
 ```
+
+### Insecure Credentials
+For contexts that don't require TLS, such as a development environment or integration
+tests, it's possible to set up a client that does not use TLS:
+
+```go
+import (
+	"github.com/authzed/grpcutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/authzed/authzed-go/v1"
+)
+
+client, err := authzed.NewClient(
+    "localhost:50051",
+    grpc.WithTransportCredentials(insecure.NewCredentials()),
+    grpcutil.WithInsecureBearerToken("some token"),
+)
+```

--- a/v1/client_test.go
+++ b/v1/client_test.go
@@ -1,10 +1,16 @@
 package authzed_test
 
 import (
+	"context"
 	"log"
+	"testing"
 
 	"github.com/authzed/grpcutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
 )
 
@@ -22,4 +28,28 @@ func ExampleNewClient() {
 		log.Fatalf("failed to connect to authzed: %s", err)
 	}
 	log.Println(client)
+}
+
+func TestWriteSchemaCall(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	// TODO: should we get a handle on the connection in order to be able to close it?
+	// It should only matter in testing, but it could still be a problem.
+	client, err := authzed.NewClient(
+		"localhost:50051",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpcutil.WithInsecureBearerToken("some token"),
+	)
+	require.NoError(err)
+
+	schema := `
+	definition document {
+		relation reader: user
+	}
+	definition user {}
+	`
+
+	_, err = client.SchemaServiceClient.WriteSchema(context.Background(), &v1.WriteSchemaRequest{Schema: schema})
+	require.NoError(err)
 }


### PR DESCRIPTION
Fixes #53 
## Description
We've had people ask about how insecure credentials work for the Go client. This provides that documentation, and also a test that validates that the syntax works. It also wires the test into the workflow.

## Changes
* Add test
* Add workflow to exercise test
* Add documentation to README
## Testing
Review. See that things are green.