### PR TITLE
Add global "security" section to swagger openapi schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE's
+.idea/

--- a/proto/apidocs.swagger.json
+++ b/proto/apidocs.swagger.json
@@ -3030,6 +3030,11 @@
       "in": "header"
     }
   },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
   "externalDocs": {
     "description": "More about the Authzed API.",
     "url": "https://docs.authzed.com/reference/api"


### PR DESCRIPTION
# 🎯 Goal
Hopefully enables ApiKeyAuth for all endpoints for proper usage with OpenAPI Generator.

# 🙋‍♂️ Situation
We are currently looking into SpiceDB as a go to option for authorization.
As of project constraints, we cannot rely upon gRPC and have to use the HTTP API.

# 🧐 The problem
Working with the API via "simple" clients (e.g. curl) works, but for proper integration a pre packaged client SDK would be really nice. As I could not find such a thing, I started on creating my own using OpenAPI generator tooling, leveraging `https://github.com/authzed/authzed-go/blob/main/proto/apidocs.swagger.json` spec file.

The client generation in general works, but using it always caused an authentication exception, which was very strange.
After debugging through the OpenAPI generated code (Java), I realised the `ApiKeyAuth` does not get applied, causing no `Authorization` header to be sent.

This is caused by the OpenAPI spec file not to be "precise" enough 😉

# 🙏 The fix
I created a quick fix to the schema that fixes the issue by setting the security to be applied to `ApiKeyAuth` for all endpoints of the schema. The generated client (Java) is now confirmed to be working.

It would be cool to have that merged to the upstream, yet there might be some open points:

# ❓ Open points
- Is the schema file auto generated (e.g. by CI) in will the change get lost with the next update to it? If so, the security config might need to be applied somewhere else.
- Need all endpoints to be secured, or are some of them to be excluded? If exclusion does not work, do we then have to explicitly annotate the endpoints and remove the global `security` configuration section?