### PR TITLE
Fix generation by tidying magefiles

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -1,7 +1,8 @@
 module github.com/authzed/authzed-go/magefiles
 
-go 1.22.7
-toolchain go1.23.1
+go 1.23.0
+
+toolchain go1.23.2
 
 require (
 	github.com/bufbuild/buf v1.50.0


### PR DESCRIPTION
## Description
Likely broke as a result of one of the dependabot PRs. This fixes `mage gen:all`.

## Changes
* Run `go mod tidy` in magefiles
## Testing
Review. See that stuff is green.